### PR TITLE
Adding support for literals as primitive types

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'org.vitrivr'
-version '0.14.1-SNAPSHOT'
+version '0.14.2'
 
 apply plugin: 'com.google.protobuf'
 apply plugin: 'idea'

--- a/src/main/kotlin/org/vitrivr/cottontail/client/language/extensions/ValueExtensions.kt
+++ b/src/main/kotlin/org/vitrivr/cottontail/client/language/extensions/ValueExtensions.kt
@@ -24,6 +24,7 @@ internal fun Any.toGrpc(): CottontailGrpc.Literal = when(this) {
     is Float -> this.toGrpc()
     is Double -> this.toGrpc()
     is String -> this.toGrpc()
+    is CottontailGrpc.Literal -> this
     else -> throw IllegalStateException("Conversion of ${this.javaClass.simpleName} to literal is not supported.")
 }
 


### PR DESCRIPTION
Currently, you cannot simply insert values you previously retrieved from cottontail, instead you have to first convert them to a supported primitive. This PR adds support for Literals to be inserted by simply not converting them.